### PR TITLE
:sparkles: check mathlib is a dependency, ignore whitespace in file check

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/oliver-butterley/lean-update-action?logo=github&sort=semver)](https://github.com/oliver-butterley/lean-update-action/releases)
 
+::: info
+For the moment it is unclear the correct
+:::
+
 This github action is for Lean projects which include Mathlib as a dependency. The action attempts to update lean and Mathlib. If an update is available then the updated version is tested. Options permit automatic committing of the updated project, opening PRs or opening issues.
 
 ## Quick setup
@@ -37,7 +41,7 @@ For the action to open an issue, the issue feature must be activated for the rep
 
 ## Details and custom configuration
 
-The action starts by attempting `lake update`. Assuming this is successful then the it attempts to build the project with the updated version. This might be successful or not. Consequently, there are three possible outcomes:
+The action starts by checking if the project has mathlib as a dependency and aborts if this isn't the case. It then updates `lean-toolchain` to match the latest version of mathlib. It then attempts `lake update`. Assuming this is successful then the action attempts to build the project with the updated version. This might be successful or not. Consequently, there are three possible outcomes:
 
 - No update available
 - Update available and build successful

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/oliver-butterley/lean-update-action?logo=github&sort=semver)](https://github.com/oliver-butterley/lean-update-action/releases)
 
 ::: info
-For the moment it is unclear the correct
+For the moment it is unclear the correct method for systematically updating a project which depends on mathlib. Consequently the development of this action should be viewed as speculative.
 :::
 
 This github action is for Lean projects which include Mathlib as a dependency. The action attempts to update lean and Mathlib. If an update is available then the updated version is tested. Options permit automatic committing of the updated project, opening PRs or opening issues.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/oliver-butterley/lean-update-action?logo=github&sort=semver)](https://github.com/oliver-butterley/lean-update-action/releases)
 
-This github action attempts to update lean and dependencies of a lean project, e.g., mathlib. If an update is available then the updated version is tested. Options permit automatic committing of the updated project, opening PRs or opening issues.
+This github action is for Lean projects which include Mathlib as a dependency. The action attempts to update lean and Mathlib. If an update is available then the updated version is tested. Options permit automatic committing of the updated project, opening PRs or opening issues.
 
 ## Quick setup
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/oliver-butterley/lean-update-action?logo=github&sort=semver)](https://github.com/oliver-butterley/lean-update-action/releases)
 
-::: info
-For the moment it is unclear the correct method for systematically updating a project which depends on mathlib. Consequently the development of this action should be viewed as speculative.
-:::
-
 This github action is for Lean projects which include Mathlib as a dependency. The action attempts to update lean and Mathlib. If an update is available then the updated version is tested. Options permit automatic committing of the updated project, opening PRs or opening issues.
+
+> ⚠️ **For the moment it is unclear the correct method for systematically updating a Lean project which depends on mathlib. Consequently the development of this action should be viewed as speculative.**
 
 ## Quick setup
 

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
       # Use git diff option -w to ignore changes in white space
       run: |
         FILENAMES=$(git diff --name-only --ignore-all-space | grep -E 'lean-toolchain|lake-manifest.json')
-        echo "::debug::Changed files: $FILENAMES"
+        echo "Changed files: $FILENAMES"
         echo "changed_files=$FILENAMES" >> "$GITHUB_OUTPUT"
         if [[ -n $(git diff -w "lean-toolchain") ]] || [[ -n $(git diff -w "lake-manifest.json") ]]; then
           echo "Updates available."

--- a/action.yml
+++ b/action.yml
@@ -31,14 +31,38 @@ runs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Check that project has Mathlib as a dependency
+      # As per https://github.com/leanprover/lean-action
+      id: check-mathlib
+      run: |
+        TOML_PATTERN="\[\[require\]\]\nname = \"mathlib\"\ngit = \"https://github.com/leanprover-community/mathlib4"
+        if grep -q "require mathlib" lakefile.lean || grep -Pzq "$TOML_PATTERN" lakefile.toml; then
+          echo "USES_MATHLIB=true" >> "$GITHUB_OUTPUT";
+        else  
+          echo "USES_MATHLIB=false" >> "$GITHUB_OUTPUT";
+        fi
+      shell: bash
+
+    - name: Give up if not using mathlib
+      if: steps.check-mathlib.outputs.uses_mathlib == 'false'
+      run: |
+        echo "This action required the lean project to have mathlib as a dependency." 
+        exit 1
+      shell: bash
+
+    - name: Update lean-toolchain
+      run: |
+        curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
+      shell: bash
+
     - name: Install elan
       run: |
         curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
         echo "$HOME/.elan/bin" >> $GITHUB_PATH
       shell: bash
 
-    - name: Update ${{ github.repository }}
-      run: lake update
+    - name: Update Mathlib dependency of ${{ github.repository }}
+      run: lake update Mathlib
       shell: bash
 
     - name: Check if anything was updated

--- a/action.yml
+++ b/action.yml
@@ -67,13 +67,21 @@ runs:
       run: lake update Mathlib
       shell: bash
 
-    - name: Check if anything was updated
-      uses: tj-actions/verify-changed-files@v20
+    - name: Check if lean-toolchain or lake-manifest.json were updated
       id: check-update
-      with:
-        files: |
-          lean-toolchain
-          lake-manifest.json
+      # Use git diff option -w to ignore changes in white space
+      run: |
+        FILENAMES=$(git diff --name-only --ignore-all-space | grep -E 'lean-toolchain|lake-manifest.json')
+        echo "::debug::Changed files: $FILENAMES"
+        echo "changed_files=$FILENAMES" >> "$GITHUB_OUTPUT"
+        if [[ -n $(git diff -w "lean-toolchain") ]] || [[ -n $(git diff -w "lake-manifest.json") ]]; then
+          echo "Updates available."
+          echo "files_changed=true" >> "$GITHUB_OUTPUT";
+        else
+          echo "No changes found."
+          echo "files_changed=false" >> "$GITHUB_OUTPUT";
+        fi
+      shell: bash
 
     - name: Try to build lean if something was updated
       if: steps.check-update.outputs.files_changed == 'true'

--- a/action.yml
+++ b/action.yml
@@ -37,16 +37,18 @@ runs:
       run: |
         TOML_PATTERN="\[\[require\]\]\nname = \"mathlib\"\ngit = \"https://github.com/leanprover-community/mathlib4"
         if grep -q "require mathlib" lakefile.lean || grep -Pzq "$TOML_PATTERN" lakefile.toml; then
-          echo "USES_MATHLIB=true" >> "$GITHUB_OUTPUT";
+          echo "USES_MATHLIB=true" >> "$GITHUB_OUTPUT"
+          echo "Project confirmed to have mathlib as a dependency.";
         else  
-          echo "USES_MATHLIB=false" >> "$GITHUB_OUTPUT";
+          echo "USES_MATHLIB=false" >> "$GITHUB_OUTPUT"
+          echo "Project does not have mathlib as a dependency.";
         fi
       shell: bash
 
     - name: Give up if not using mathlib
       if: steps.check-mathlib.outputs.uses_mathlib == 'false'
       run: |
-        echo "This action required the lean project to have mathlib as a dependency." 
+        echo "This action requires the lean project to have mathlib as a dependency." 
         exit 1
       shell: bash
 


### PR DESCRIPTION
Added features:
- Check that the lean project has mathlib as a dependency before proceeding.
- Check if lean-toolchain or lake-manifest.json have been modified directly, using bash script and without using another action as before.
- Check if lean-toolchain or lake-manifest.json now ignores white space differences. (Closes issue #2 )
- Updates `lean-toolchain` directly using curl prior to running lake update. (Closes issue #3 )

