### PR TITLE
make this action mathlib-independent

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       if: steps.check-update.outputs.files_changed == 'true'
       id: build-lean
       continue-on-error: true
-      uses: Seasawher/lean-action@patch-1
+      uses: leanprover/lean-action@v1-beta
       with:
         test: false
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
       Default: "silent".
     required: true
     default: "silent"
-  token: 
+  token:
     description: |
       A Github token to be used for committing
     required: true
@@ -28,22 +28,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-
-    - name: Check that project has Mathlib as a dependency
-      id: check-mathlib
-      run: |
-        OUTCOME=$(bash ${{ github.action_path }}/check-mathlib.sh)
-        echo "$OUTCOME" >> "$GITHUB_OUTPUT"
-        echo "info: $OUTCOME"
-      shell: bash
-
-    - name: Give up if not using mathlib
-      if: steps.check-mathlib.outputs.uses_mathlib == 'false'
-      run: |
-        echo "This action requires the lean project to have mathlib as a dependency." 
-        exit 1
-      shell: bash
-
     - name: Update lean-toolchain
       run: |
         curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
@@ -71,10 +55,9 @@ runs:
       if: steps.check-update.outputs.files_changed == 'true'
       id: build-lean
       continue-on-error: true
-      run: |
-        lake exe cache get || true
-        lake build
-      shell: bash
+      uses: leanprover/lean-action@v1-beta
+      with:
+        test: false
 
     - name: Record outcome
       id: record-outcome
@@ -120,7 +103,7 @@ runs:
     - name: Commit update if the updated lean build was successful
       if: steps.build-lean.outcome == 'success' && inputs.on_update_succeeds == 'commit'
       uses: EndBug/add-and-commit@v9.1.4
-      with: 
+      with:
         default_author: github_actions
 
     - name: Open issue if the updated lean build fails

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
       if: steps.check-update.outputs.files_changed == 'true'
       id: build-lean
       continue-on-error: true
-      uses: leanprover/lean-action@v1-beta
+      uses: leanprover/lean-action@main
       with:
         test: false
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,11 @@ runs:
   steps:
     - name: Update lean-toolchain
       run: |
-        curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
+        LATEST_LEAN=$(gh release list --repo leanprover/lean4 --limit 1 | awk '{print $1}')
+        echo "The latest release/prerelase is: $LATEST_LEAN"
+        echo "leanprover/lean4:$LATEST_LEAN" > lean-toolchain
+      env:
+        GH_TOKEN: ${{ github.token }}
       shell: bash
 
     - name: Install elan

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       if: steps.check-update.outputs.files_changed == 'true'
       id: build-lean
       continue-on-error: true
-      uses: leanprover/lean-action@v1-beta
+      uses: Seasawher/lean-action@patch-1
       with:
         test: false
 


### PR DESCRIPTION
I tested this action here: https://github.com/Seasawher/mk-exercise

Changed so that Lean version updates are also performed in repositories that are not downstream of mathlib.